### PR TITLE
feat: Implement AWS Config resource scanning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ idled --services ec2,ebs
 idled --services s3
 idled --services lambda
 idled --services iam
-idled --services ec2,ebs,s3,lambda,iam
+idled --services config
+idled --services ec2,ebs,s3,lambda,iam,config
 ```
 
 Check CLI version:
@@ -101,24 +102,27 @@ This tool uses the AWS SDK's default credential chain:
 
 ## Supported Services
 
-### Amazon Web Services
-
-| Service    | Status       | Resource Description          | Remark |
-|------------|--------------|--------------------------------|--------|
-| EC2        | ✅ Supported | Stopped EC2 instances          | -      |
-| EBS        | ✅ Supported | Unattached EBS volumes         | Not available IOPS and throughput calculation, Only available volume size |
-| S3         | ✅ Supported | Idle S3 buckets                | Empty buckets, buckets with no recent modifications or API activity |
-| Lambda     | ✅ Supported | Idle Lambda functions          | Functions with no invocations or minimal usage in last 30 days |
-| EIP        | ✅ Supported | Unattached Elastic IPs         | -      |
-| IAM        | ✅ Supported | Idle IAM users, roles, policies | Users and roles with no activity for 90+ days, unattached policies |
-| ELB        | ⏳ Planned   | Load balancers with no targets | -      |
+| Service | Status | Resource | Remarks |
+|---------|--------|----------|---------|
+| EC2     | ✅     | Stopped EC2 instances | Detects stopped EC2 instances |
+| EBS     | ✅     | Unattached EBS volumes | Detects unattached EBS volumes |
+| S3      | ✅     | Idle S3 buckets | Detects idle S3 buckets |
+| Lambda  | ✅     | Idle Lambda functions | Detects idle Lambda functions |
+| EIP     | ✅     | Unattached Elastic IPs | Detects unattached Elastic IPs |
+| IAM     | ✅     | Idle IAM users, roles, and policies | Detects unused IAM resources |
+| Config  | ✅     | Idle Config rules, recorders, and delivery channels | Detects unused Config resources |
 
 ## Documentation
 
-Detailed documentation is available in the `docs/` directory:
+For more details about each resource detection, refer to the following documents:
 
-- [Cost Savings Calculation](docs/cost-savings-calculation.md) - How cost savings are calculated for each resource type
-- [Project Structure](docs/project-structure.md) - Layout and organization of the codebase
+- [EC2 Instance Detection](docs/ec2.md)
+- [EBS Volume Detection](docs/ebs.md)
+- [S3 Bucket Detection](docs/s3.md)
+- [Lambda Function Detection](docs/lambda.md)
+- [EIP Detection](docs/eip.md)
+- [IAM Resource Detection](docs/iam.md)
+- [AWS Config Detection](docs/config.md)
 
 ## Implementation Details
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This tool uses the AWS SDK's default credential chain:
 | EIP     | ✅     | Unattached Elastic IPs | Detects unattached Elastic IPs |
 | IAM     | ✅     | Idle IAM users, roles, and policies | Detects unused IAM resources |
 | Config  | ✅     | Idle Config rules, recorders, and delivery channels | Detects unused Config resources |
+| ELB     | ⏳ Planned   | Load balancers with no targets | -      |
 
 ## Documentation
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -14,7 +14,9 @@ idled/
 │       ├── ec2.go
 │       ├── ebs.go
 │       ├── s3.go
-│       └── iam.go
+│       ├── iam.go
+│       ├── config.go
+│       └── lambda.go
 ├── pkg/
 │   ├── aws/          # AWS API wrapper
 │   │   ├── ec2.go
@@ -22,6 +24,7 @@ idled/
 │   │   ├── s3.go
 │   │   ├── lambda.go
 │   │   ├── iam.go
+│   │   ├── config.go
 │   │   ├── ec2_pricing.go
 │   │   └── ebs_pricing.go
 │   ├── formatter/    # Output formatters
@@ -29,12 +32,14 @@ idled/
 │   │   ├── ebs_table.go
 │   │   ├── s3_table.go
 │   │   ├── lambda_table.go
-│   │   └── iam_table.go
+│   │   ├── iam_table.go
+│   │   └── config_table.go
 │   └── utils/        # Utility functions
 │       └── format.go
 ├── docs/             # Documentation
 │   ├── cost-savings-calculation.md
 │   ├── project-structure.md
+│   ├── config.md
 │   └── iam.md
 ├── Makefile          # Build automation
 ├── go.mod
@@ -186,3 +191,41 @@ The IAM idle resource detection is implemented with the following components:
 - Shows real-time progress for IAM operations
 - Displays the current stage of analysis and overall completion percentage
 - Indicates resource count and processing status for each resource type
+
+## Config Implementation Details
+
+The AWS Config resource detection is implemented with the following components:
+
+### 1. Data Model (`internal/models/config.go`)
+
+- Defines the data structures for Config Rules, Recorders, and Delivery Channels
+- Includes fields for tracking:
+  - Resource identifiers (name, ARN, ID)
+  - Creation and last modified timestamps
+  - Active/inactive status and compliance status
+  - Configuration settings (resource types, delivery settings)
+  - Activity metrics and idle status determination
+
+### 2. AWS Client (`pkg/aws/config.go`)
+
+- Implements AWS Config API operations using AWS SDK v2
+- Provides methods to:
+  - List all Config Rules, Recorders, and Delivery Channels in each region
+  - Analyze rule evaluation status and compliance
+  - Check recorder status and configuration
+  - Examine delivery channel settings and activity
+  - Calculate idle days based on last activity times
+  - Determine if resources are idle based on configurable criteria
+
+### 3. Output Formatter (`pkg/formatter/config_table.go`)
+
+- Displays Config resource information in tabular format
+- Shows key metrics like compliance status, recording status, and idle days
+- Groups resources by type and sorts by activity status
+- Provides summary statistics for each resource type
+
+### 4. Progress Indication
+
+- Shows real-time progress for Config operations
+- Displays the current region being processed
+- Provides overall status and resource count metrics

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/service/configservice v1.52.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 h1:ZNTqv4nIdE/DiBfUUfXcLZ/Spcu
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34/go.mod h1:zf7Vcd1ViW7cPqYWEHLHJkS50X0JS2IKz9Cgaj6ugrs=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.0 h1:0cF07Fs0CT8XSLGGFqp0VNJD+sb447S8UQU7hz95xJo=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.0/go.mod h1:HJlcOk+S/wjJuR/8jPa8GhnEKdKqqiQ5wjsE1PjuO1o=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.52.3 h1:Gw9GpbCShTzWPezPKdiV8yGFbQ/yLb+NircxQUGXC0I=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.52.3/go.mod h1:nJdDaoBiWBPdMaARQFA5xXHS0CHpxRzGbdp7QYqAVK0=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.211.2 h1:KMoQ43HysbPqs1vufMn9h2UcUyc2WCMaKxYhExKJZuo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.211.2/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
 github.com/aws/aws-sdk-go-v2/service/iam v1.32.6 h1:NRlKKQ/BPHPqsuN2Hy6v4WA8/bsRTP0j8/BFPBC5+SU=

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"time"
+)
+
+// ConfigRuleInfo holds information about an AWS Config rule
+type ConfigRuleInfo struct {
+	// Basic information
+	RuleName       string
+	RuleID         string
+	ARN            string
+	CreatedTime    *time.Time
+	LastUpdateTime *time.Time
+	Region         string
+
+	// Status information
+	IsActive       bool
+	IsCustom       bool
+	IsCompliant    bool
+	EvaluationMode string
+
+	// Idle detection
+	IdleDays     int
+	IsIdle       bool
+	LastActivity *time.Time
+}
+
+// ConfigRecorderInfo holds information about an AWS Config recorder
+type ConfigRecorderInfo struct {
+	// Basic information
+	RecorderName   string
+	RecorderID     string
+	Region         string
+	CreatedTime    *time.Time
+	LastUpdateTime *time.Time
+
+	// Configuration
+	AllResourceTypes bool
+	ResourceCount    int
+	IsRecording      bool
+
+	// Idle detection
+	IdleDays     int
+	IsIdle       bool
+	LastActivity *time.Time
+}
+
+// ConfigDeliveryChannelInfo holds information about a Config delivery channel
+type ConfigDeliveryChannelInfo struct {
+	// Basic information
+	ChannelName string
+	ChannelID   string
+	Region      string
+	CreatedTime *time.Time
+
+	// Configuration
+	S3BucketName string
+	SNSTopicARN  string
+	Frequency    string
+
+	// Idle detection
+	IdleDays     int
+	IsIdle       bool
+	LastActivity *time.Time
+}

--- a/pkg/aws/config.go
+++ b/pkg/aws/config.go
@@ -1,0 +1,380 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
+	"github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	"github.com/younsl/idled/internal/models"
+)
+
+// ConfigClient represents an AWS Config client
+type ConfigClient struct {
+	client *configservice.Client
+	region string
+}
+
+// ConfigRule represents an AWS Config rule
+type ConfigRule struct {
+	Name           string
+	ARN            string
+	LastModified   time.Time
+	CreationTime   time.Time
+	Region         string
+	State          string
+	LastEvaluation time.Time
+}
+
+// ConfigRecorder represents an AWS Config recorder
+type ConfigRecorder struct {
+	Name         string
+	ARN          string
+	LastStatus   string
+	Region       string
+	LastStarted  time.Time
+	LastStopped  time.Time
+	RecordingAll bool
+}
+
+// DeliveryChannel represents an AWS Config delivery channel
+type DeliveryChannel struct {
+	Name             string
+	Region           string
+	S3BucketName     string
+	S3KeyPrefix      string
+	SNSTopicARN      string
+	LastChangeTime   time.Time
+	ConfigSnapshotOn bool
+}
+
+// NewConfigClient creates a new AWS Config client
+func NewConfigClient(region string) (*ConfigClient, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config for region %s: %w", region, err)
+	}
+
+	return &ConfigClient{
+		client: configservice.NewFromConfig(cfg, func(o *configservice.Options) {
+			o.Region = region
+		}),
+		region: region,
+	}, nil
+}
+
+// GetAllConfigRules returns a list of models.ConfigRuleInfo objects representing Config rules
+func (c *ConfigClient) GetAllConfigRules() ([]models.ConfigRuleInfo, error) {
+	ctx := context.Background()
+
+	input := &configservice.DescribeConfigRulesInput{}
+	resp, err := c.client.DescribeConfigRules(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	var configRules []models.ConfigRuleInfo
+	cutoffTime := time.Now().AddDate(0, 0, -90) // Default to 90 days for idle
+
+	for _, rule := range resp.ConfigRules {
+		// Initialize with default values
+		now := time.Now()
+		var createdTime time.Time = now
+		var lastActivity time.Time = now
+
+		// Convert to our model
+		configRule := models.ConfigRuleInfo{
+			RuleName: *rule.ConfigRuleName,
+			RuleID:   *rule.ConfigRuleId,
+			ARN:      *rule.ConfigRuleArn,
+			Region:   c.region,
+			IsActive: rule.ConfigRuleState == types.ConfigRuleState("ACTIVE"),
+			IsCustom: rule.Source != nil && rule.Source.Owner != types.Owner("AWS"),
+		}
+
+		// Set creation time pointer
+		configRule.CreatedTime = &createdTime
+		configRule.LastActivity = &lastActivity
+
+		// Check rule evaluations for compliance status
+		complianceInput := &configservice.DescribeComplianceByConfigRuleInput{
+			ConfigRuleNames: []string{*rule.ConfigRuleName},
+		}
+		complianceResp, err := c.client.DescribeComplianceByConfigRule(ctx, complianceInput)
+		if err == nil && len(complianceResp.ComplianceByConfigRules) > 0 {
+			for _, compliance := range complianceResp.ComplianceByConfigRules {
+				// Set compliance status
+				if compliance.Compliance != nil {
+					configRule.IsCompliant = compliance.Compliance.ComplianceType == types.ComplianceType("COMPLIANT")
+				}
+			}
+		}
+
+		// Try to get more detailed timing information from ConfigRuleEvaluationStatus
+		statusInput := &configservice.DescribeConfigRuleEvaluationStatusInput{
+			ConfigRuleNames: []string{*rule.ConfigRuleName},
+		}
+		statusResp, err := c.client.DescribeConfigRuleEvaluationStatus(ctx, statusInput)
+		if err == nil && len(statusResp.ConfigRulesEvaluationStatus) > 0 {
+			status := statusResp.ConfigRulesEvaluationStatus[0]
+
+			// Update creation time if available
+			if status.FirstActivatedTime != nil {
+				createdTime = *status.FirstActivatedTime
+				configRule.CreatedTime = &createdTime
+				configRule.LastActivity = &createdTime // Default last activity to creation
+			}
+
+			// Update last activity time based on the most recent evaluation
+			if status.LastSuccessfulEvaluationTime != nil {
+				lastActivity = *status.LastSuccessfulEvaluationTime
+				configRule.LastActivity = &lastActivity
+			}
+
+			// If error occurred more recently, use that time
+			if status.LastFailedEvaluationTime != nil &&
+				status.LastFailedEvaluationTime.After(lastActivity) {
+				lastActivity = *status.LastFailedEvaluationTime
+				configRule.LastActivity = &lastActivity
+			}
+		}
+
+		// Calculate idle days
+		configRule.IdleDays = int(time.Since(lastActivity).Hours() / 24)
+		configRule.IsIdle = lastActivity.Before(cutoffTime)
+
+		// 모든 규칙을 추가 (유휴 상태 필터링 제거)
+		configRules = append(configRules, configRule)
+	}
+
+	return configRules, nil
+}
+
+// GetAllConfigRecorders returns a list of models.ConfigRecorderInfo objects representing Config recorders
+func (c *ConfigClient) GetAllConfigRecorders() ([]models.ConfigRecorderInfo, error) {
+	ctx := context.Background()
+	var recorders []models.ConfigRecorderInfo
+
+	input := &configservice.DescribeConfigurationRecordersInput{}
+	resp, err := c.client.DescribeConfigurationRecorders(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	statusInput := &configservice.DescribeConfigurationRecorderStatusInput{}
+	statusResp, err := c.client.DescribeConfigurationRecorderStatus(ctx, statusInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map status by recorder name
+	statusMap := make(map[string]types.ConfigurationRecorderStatus)
+	for _, status := range statusResp.ConfigurationRecordersStatus {
+		if status.Name != nil {
+			statusMap[*status.Name] = status
+		}
+	}
+
+	for _, recorder := range resp.ConfigurationRecorders {
+		if recorder.Name == nil {
+			continue
+		}
+
+		configRecorder := models.ConfigRecorderInfo{
+			RecorderName:     *recorder.Name,
+			RecorderID:       *recorder.Name,
+			Region:           c.region,
+			IsRecording:      false,
+			AllResourceTypes: false,
+		}
+
+		// Get the recording status
+		if recorder.RecordingGroup != nil {
+			configRecorder.AllResourceTypes = recorder.RecordingGroup.AllSupported
+			configRecorder.ResourceCount = len(recorder.RecordingGroup.ResourceTypes)
+		}
+
+		// Get status details if available
+		var lastActivity time.Time
+		lastActivitySet := false
+		if status, ok := statusMap[*recorder.Name]; ok {
+			if status.LastStartTime != nil {
+				lastActivity = *status.LastStartTime
+				lastActivitySet = true
+			}
+			if status.LastStopTime != nil &&
+				(status.LastStopTime.After(lastActivity) || !lastActivitySet) {
+				lastActivity = *status.LastStopTime
+				lastActivitySet = true
+			}
+
+			// Recording status is a boolean in SDK v2
+			configRecorder.IsRecording = status.Recording
+		}
+
+		// Set last activity and idle status if we have timing data
+		if lastActivitySet {
+			activityTime := lastActivity
+			configRecorder.LastActivity = &activityTime
+			configRecorder.IdleDays = int(time.Since(lastActivity).Hours() / 24)
+			configRecorder.IsIdle = configRecorder.IdleDays > 90
+		}
+
+		// 모든 레코더 추가 (유휴 상태 필터링 제거)
+		recorders = append(recorders, configRecorder)
+	}
+
+	return recorders, nil
+}
+
+// GetAllConfigDeliveryChannels returns a list of models.ConfigDeliveryChannelInfo objects
+func (c *ConfigClient) GetAllConfigDeliveryChannels() ([]models.ConfigDeliveryChannelInfo, error) {
+	ctx := context.Background()
+	var channels []models.ConfigDeliveryChannelInfo
+
+	input := &configservice.DescribeDeliveryChannelsInput{}
+	resp, err := c.client.DescribeDeliveryChannels(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, channel := range resp.DeliveryChannels {
+		if channel.Name == nil {
+			continue
+		}
+
+		deliveryChannel := models.ConfigDeliveryChannelInfo{
+			ChannelName: *channel.Name,
+			ChannelID:   *channel.Name,
+			Region:      c.region,
+		}
+
+		if channel.S3BucketName != nil {
+			deliveryChannel.S3BucketName = *channel.S3BucketName
+		}
+		if channel.SnsTopicARN != nil {
+			deliveryChannel.SNSTopicARN = *channel.SnsTopicARN
+		}
+
+		// Set frequency if available
+		if channel.ConfigSnapshotDeliveryProperties != nil &&
+			channel.ConfigSnapshotDeliveryProperties.DeliveryFrequency != "" {
+			deliveryChannel.Frequency = string(channel.ConfigSnapshotDeliveryProperties.DeliveryFrequency)
+		}
+
+		// Get the delivery channel status for last activity time
+		statusInput := &configservice.DescribeDeliveryChannelStatusInput{
+			DeliveryChannelNames: []string{*channel.Name},
+		}
+		statusResp, err := c.client.DescribeDeliveryChannelStatus(ctx, statusInput)
+		if err == nil && len(statusResp.DeliveryChannelsStatus) > 0 {
+			var lastActivity time.Time
+			lastActivitySet := false
+
+			if statusResp.DeliveryChannelsStatus[0].ConfigHistoryDeliveryInfo != nil &&
+				statusResp.DeliveryChannelsStatus[0].ConfigHistoryDeliveryInfo.LastSuccessfulTime != nil {
+				lastActivity = *statusResp.DeliveryChannelsStatus[0].ConfigHistoryDeliveryInfo.LastSuccessfulTime
+				lastActivitySet = true
+			}
+
+			if statusResp.DeliveryChannelsStatus[0].ConfigStreamDeliveryInfo != nil &&
+				statusResp.DeliveryChannelsStatus[0].ConfigStreamDeliveryInfo.LastStatusChangeTime != nil &&
+				(statusResp.DeliveryChannelsStatus[0].ConfigStreamDeliveryInfo.LastStatusChangeTime.After(lastActivity) ||
+					!lastActivitySet) {
+				lastActivity = *statusResp.DeliveryChannelsStatus[0].ConfigStreamDeliveryInfo.LastStatusChangeTime
+				lastActivitySet = true
+			}
+
+			// Set last activity and determine if idle
+			if lastActivitySet {
+				activityTime := lastActivity
+				deliveryChannel.LastActivity = &activityTime
+				deliveryChannel.IdleDays = int(time.Since(lastActivity).Hours() / 24)
+				deliveryChannel.IsIdle = deliveryChannel.IdleDays > 90 // Default 90 days for idle
+			}
+		}
+
+		// 모든 전송 채널 추가
+		channels = append(channels, deliveryChannel)
+	}
+
+	return channels, nil
+}
+
+// GetAllConfigResources retrieves all AWS Config resources across all regions
+func GetAllConfigResources(regions []string, idleDays int) ([]models.ConfigRuleInfo, []models.ConfigRecorderInfo, []models.ConfigDeliveryChannelInfo, error) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var allRules []models.ConfigRuleInfo
+	var allRecorders []models.ConfigRecorderInfo
+	var allChannels []models.ConfigDeliveryChannelInfo
+	var errs []error
+
+	for _, region := range regions {
+		wg.Add(1)
+		go func(region string) {
+			defer wg.Done()
+
+			client, err := NewConfigClient(region)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("failed to load AWS config for region %s: %w", region, err))
+				mu.Unlock()
+				return
+			}
+
+			// Get all Config rules
+			rules, err := client.GetAllConfigRules()
+			if err == nil {
+				mu.Lock()
+				allRules = append(allRules, rules...)
+				mu.Unlock()
+			} else {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+
+			// Get all Config recorders
+			recorders, err := client.GetAllConfigRecorders()
+			if err == nil {
+				mu.Lock()
+				allRecorders = append(allRecorders, recorders...)
+				mu.Unlock()
+			} else {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+
+			// Get all delivery channels
+			channels, err := client.GetAllConfigDeliveryChannels()
+			if err == nil {
+				mu.Lock()
+				allChannels = append(allChannels, channels...)
+				mu.Unlock()
+			} else {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+		}(region)
+	}
+
+	wg.Wait()
+
+	// If we got some results but had some errors, we'll still return what we found
+	if len(allRules) > 0 || len(allRecorders) > 0 || len(allChannels) > 0 {
+		return allRules, allRecorders, allChannels, nil
+	}
+
+	// If we have no results and have errors, return the first error
+	if len(errs) > 0 {
+		return nil, nil, nil, errs[0]
+	}
+
+	return allRules, allRecorders, allChannels, nil
+}

--- a/pkg/formatter/config_table.go
+++ b/pkg/formatter/config_table.go
@@ -1,0 +1,240 @@
+package formatter
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/younsl/idled/internal/models"
+)
+
+// FormatConfigRulesTable writes AWS Config rules information in a table format
+func FormatConfigRulesTable(writer io.Writer, rules []models.ConfigRuleInfo) {
+	if len(rules) == 0 {
+		fmt.Fprintln(writer, "No AWS Config rules found.")
+		return
+	}
+
+	// Sort rules: idle rules first, then by idle days (descending)
+	sort.Slice(rules, func(i, j int) bool {
+		if rules[i].IsIdle != rules[j].IsIdle {
+			return rules[i].IsIdle // true comes first
+		}
+		return rules[i].IdleDays > rules[j].IdleDays
+	})
+
+	// Create tabwriter for aligned output
+	w := tabwriter.NewWriter(writer, 0, 0, 3, ' ', tabwriter.TabIndent)
+
+	// Print header
+	fmt.Fprintln(w, "RULE NAME\tRULE ID\tCUSTOM\tSTATUS\tCOMPLIANT\tEVALUATION MODE\tLAST ACTIVITY\tIDLE\tREGION")
+
+	// Print each rule
+	for _, rule := range rules {
+		lastActivityStr := "Never"
+		if rule.LastActivity != nil {
+			lastActivityStr = formatDate(*rule.LastActivity)
+		}
+
+		statusStr := "Inactive"
+		if rule.IsActive {
+			statusStr = "Active"
+		}
+
+		customStr := "No"
+		if rule.IsCustom {
+			customStr = "Yes"
+		}
+
+		compliantStr := "Unknown"
+		if rule.IsActive {
+			if rule.IsCompliant {
+				compliantStr = "Yes"
+			} else {
+				compliantStr = "No"
+			}
+		}
+
+		idleStatus := "No"
+		if rule.IsIdle {
+			idleStatus = "Yes"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			rule.RuleName,
+			rule.RuleID,
+			customStr,
+			statusStr,
+			compliantStr,
+			rule.EvaluationMode,
+			lastActivityStr,
+			idleStatus,
+			rule.Region,
+		)
+	}
+
+	w.Flush()
+
+	// Print summary
+	idleCount := 0
+	customCount := 0
+	inactiveCount := 0
+
+	for _, rule := range rules {
+		if rule.IsIdle {
+			idleCount++
+		}
+		if rule.IsCustom {
+			customCount++
+		}
+		if !rule.IsActive {
+			inactiveCount++
+		}
+	}
+
+	fmt.Fprintf(writer, "\nSummary: %d idle AWS Config rules out of %d total rules (%d custom, %d inactive)\n",
+		idleCount, len(rules), customCount, inactiveCount)
+}
+
+// FormatConfigRecordersTable writes AWS Config recorders information in a table format
+func FormatConfigRecordersTable(writer io.Writer, recorders []models.ConfigRecorderInfo) {
+	if len(recorders) == 0 {
+		fmt.Fprintln(writer, "No AWS Config recorders found.")
+		return
+	}
+
+	// Sort recorders: idle recorders first, then by idle days (descending)
+	sort.Slice(recorders, func(i, j int) bool {
+		if recorders[i].IsIdle != recorders[j].IsIdle {
+			return recorders[i].IsIdle // true comes first
+		}
+		return recorders[i].IdleDays > recorders[j].IdleDays
+	})
+
+	// Create tabwriter for aligned output
+	w := tabwriter.NewWriter(writer, 0, 0, 3, ' ', tabwriter.TabIndent)
+
+	// Print header
+	fmt.Fprintln(w, "RECORDER NAME\tSTATUS\tRESOURCE COVERAGE\tLAST ACTIVITY\tIDLE DAYS\tIDLE\tREGION")
+
+	// Print each recorder
+	for _, recorder := range recorders {
+		lastActivityStr := "Never"
+		if recorder.LastActivity != nil {
+			lastActivityStr = formatDate(*recorder.LastActivity)
+		}
+
+		statusStr := "Not Recording"
+		if recorder.IsRecording {
+			statusStr = "Recording"
+		}
+
+		resourceCoverageStr := fmt.Sprintf("%d resources", recorder.ResourceCount)
+		if recorder.AllResourceTypes {
+			resourceCoverageStr = "All resources"
+		}
+
+		idleStatus := "No"
+		if recorder.IsIdle {
+			idleStatus = "Yes"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+			recorder.RecorderName,
+			statusStr,
+			resourceCoverageStr,
+			lastActivityStr,
+			recorder.IdleDays,
+			idleStatus,
+			recorder.Region,
+		)
+	}
+
+	w.Flush()
+
+	// Print summary
+	idleCount := 0
+	notRecordingCount := 0
+
+	for _, recorder := range recorders {
+		if recorder.IsIdle {
+			idleCount++
+		}
+		if !recorder.IsRecording {
+			notRecordingCount++
+		}
+	}
+
+	fmt.Fprintf(writer, "\nSummary: %d idle AWS Config recorders out of %d total recorders (%d not recording)\n",
+		idleCount, len(recorders), notRecordingCount)
+}
+
+// FormatConfigDeliveryChannelsTable writes AWS Config delivery channels information in a table format
+func FormatConfigDeliveryChannelsTable(writer io.Writer, channels []models.ConfigDeliveryChannelInfo) {
+	if len(channels) == 0 {
+		fmt.Fprintln(writer, "No AWS Config delivery channels found.")
+		return
+	}
+
+	// Sort channels: idle channels first, then by idle days (descending)
+	sort.Slice(channels, func(i, j int) bool {
+		if channels[i].IsIdle != channels[j].IsIdle {
+			return channels[i].IsIdle // true comes first
+		}
+		return channels[i].IdleDays > channels[j].IdleDays
+	})
+
+	// Create tabwriter for aligned output
+	w := tabwriter.NewWriter(writer, 0, 0, 3, ' ', tabwriter.TabIndent)
+
+	// Print header
+	fmt.Fprintln(w, "CHANNEL NAME\tS3 BUCKET\tSNS TOPIC\tFREQUENCY\tLAST ACTIVITY\tIDLE DAYS\tIDLE\tREGION")
+
+	// Print each channel
+	for _, channel := range channels {
+		lastActivityStr := "Never"
+		if channel.LastActivity != nil {
+			lastActivityStr = formatDate(*channel.LastActivity)
+		}
+
+		snsTopicStr := "-"
+		if channel.SNSTopicARN != "" {
+			snsTopicStr = channel.SNSTopicARN
+		}
+
+		frequencyStr := "Not set"
+		if channel.Frequency != "" {
+			frequencyStr = channel.Frequency
+		}
+
+		idleStatus := "No"
+		if channel.IsIdle {
+			idleStatus = "Yes"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+			channel.ChannelName,
+			channel.S3BucketName,
+			snsTopicStr,
+			frequencyStr,
+			lastActivityStr,
+			channel.IdleDays,
+			idleStatus,
+			channel.Region,
+		)
+	}
+
+	w.Flush()
+
+	// Print summary
+	idleCount := 0
+	for _, channel := range channels {
+		if channel.IsIdle {
+			idleCount++
+		}
+	}
+
+	fmt.Fprintf(writer, "\nSummary: %d idle AWS Config delivery channels out of %d total delivery channels\n",
+		idleCount, len(channels))
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR implements AWS Config resource scanning support in idled. It allows users to detect and analyze Config Rules, Config Recorders, and Config Delivery Channels across AWS regions. This enhances the tool's capability to identify potentially unused AWS resources, helping users optimize their AWS environments and reduce costs.

The implementation:
- Adds AWS Config client to scan Config resources using AWS SDK v2
- Creates data models to represent Config Rules, Recorders, and Delivery Channels
- Implements table formatters to display Config resources in a clean, readable format
- Adds spinner UI for real-time progress indication during Config scanning
- Shows all Config resources with idle status markers for better context
- Includes comprehensive documentation for AWS Config resource detection

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
The implementation now displays all Config resources rather than filtering to only show idle ones. This is a deliberate design choice to provide users with complete visibility into their Config resources while still highlighting idle ones. The code also handles both AWS-managed and customer-managed Config Rules appropriately.

#### Additional documentation:
- Added `docs/config.md` with detailed explanation of the Config resource detection methodology
- Updated `docs/project-structure.md` to include Config implementation details
- Added examples to README.md for scanning Config resources

#### Testing done:
- Manually verified detection of Config Rules, Recorders, and Delivery Channels in multiple regions
- Tested idle status calculation for resources with different activity patterns
- Verified spinner UI functionality during scanning operations
- Confirmed proper display of all Config resources in tabular format
- Tested the command with various region configurations
